### PR TITLE
Avoid RSpec warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color always
+--format documentation
+--require spec_helper

--- a/panko.gemspec
+++ b/panko.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "breadcrumbs_on_rails"
   spec.add_dependency "i18n"
   spec.add_dependency "activesupport"
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/spec/crud_spec.rb
+++ b/spec/crud_spec.rb
@@ -1,21 +1,26 @@
 require "spec_helper"
 require "panko/crud"
 
-class Item
-  def to_s
-    "Item 123"
-  end
-end
-
-class ItemBreadcrumbs < Panko::Crud
-end
-
 describe Panko::Crud, "#build" do
+  let(:item_class) do
+    Class.new do
+      def to_s
+        "Item 123"
+      end
+    end
+  end
+
+  let(:item_breadcrumbs_class) do
+    Class.new(Panko::Crud)
+  end
+
   before do
+    stub_const("Item", item_class)
+    stub_const("ItemBreadcrumbs", item_breadcrumbs_class)
     expect_i18n "layout.breadcrumb_root" => "My root",
                 "items.index.title"      => "Items"
 
-    controller.stub(root_path: "/")
+    allow(controller).to receive(:root_path).and_return("/")
     expect_url_for [ Item ] => "/items"
   end
 


### PR DESCRIPTION
 - no constants defined outside the RSpec scope
 - avoid warnings about stub
 - allow Bundler 2